### PR TITLE
chore: add CI workflow for formula auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    name: Formula Audit
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Tap this repository
+        run: |
+          mkdir -p "$(brew --repository)/Library/Taps/cliffmin"
+          ln -s "$GITHUB_WORKSPACE" "$(brew --repository)/Library/Taps/cliffmin/homebrew-tap"
+
+      - name: Audit voxcore formula
+        run: brew audit --strict Formula/voxcore.rb
+
+      - name: Audit voxcompose formula
+        run: brew audit --strict Formula/voxcompose.rb
+
+      - name: Check formula style
+        run: |
+          brew style Formula/voxcore.rb || true
+          brew style Formula/voxcompose.rb || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Tap this repository
+      - name: Tap from workspace
         run: |
-          mkdir -p "$(brew --repository)/Library/Taps/cliffmin"
-          ln -s "$GITHUB_WORKSPACE" "$(brew --repository)/Library/Taps/cliffmin/homebrew-tap"
+          brew tap cliffmin/tap "$GITHUB_WORKSPACE"
 
-      - name: Audit voxcore formula
-        run: brew audit --strict Formula/voxcore.rb
-
-      - name: Audit voxcompose formula
-        run: brew audit --strict Formula/voxcompose.rb
+      - name: Audit formulae
+        run: |
+          brew audit --strict cliffmin/tap/voxcore
+          brew audit --strict cliffmin/tap/voxcompose
 
       - name: Check formula style
         run: |
-          brew style Formula/voxcore.rb || true
-          brew style Formula/voxcompose.rb || true
+          brew style cliffmin/tap/voxcore || true
+          brew style cliffmin/tap/voxcompose || true


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow that runs `brew audit --strict` and `brew style` on both formulas (voxcore, voxcompose) for every push and PR to main.

## Context

The tap had no CI. This catches formula syntax issues, style violations, and broken URLs before they reach users.

## Note

The voxcore formula still references the deprecated daemon architecture (PTTServiceDaemon, whisper-post.jar, brew services). This predates the v0.6.0 CLI migration and should be updated in a follow-up PR.

Made with [Cursor](https://cursor.com)